### PR TITLE
Make a small adjustment to hack/update-deps.sh

### DIFF
--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -14,13 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/library.sh
+readonly ROOT_DIR=$(dirname $0)/..
+source ${ROOT_DIR}/vendor/github.com/knative/test-infra/scripts/library.sh
 
 set -o errexit
 set -o nounset
 set -o pipefail
 
-cd ${REPO_ROOT_DIR}
+cd ${ROOT_DIR}
 
 # Ensure we have everything we need under vendor/
 dep ensure


### PR DESCRIPTION
This form should be more hospitable to running things to auto-update `knative/pkg` and `knative/test-infra`

Once this merges, I will test my auto-update script for `knative/pkg` and `knative/test-infra` and if all goes well, start mirroring this change to the other repositories.