### PR TITLE
Fix presubmit test argument passing

### DIFF
--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -31,4 +31,4 @@ source $(dirname $0)/../vendor/knative.dev/test-infra/scripts/presubmit-tests.sh
 
 # We use the default build, unit and integration test runners.
 
-main $@
+main "$@"


### PR DESCRIPTION
Per discussion at https://knative.slack.com/archives/CA1DTGZ2N/p1585081013164500 we want to do `main "$@"` instead of `main $@` in order to have correct custom argument parsing using `parse_flags()` callback.