### PR TITLE
Include empty list of validating callbacks

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -43,6 +43,8 @@ var types = map[schema.GroupVersionKind]resourcesemantics.GenericCRD{
 	v1alpha1.SchemeGroupVersion.WithKind("AddressableService"): &v1alpha1.AddressableService{},
 }
 
+var callbacks = map[schema.GroupVersionKind]validation.Callback{}
+
 func NewDefaultingAdmissionController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
 	return defaulting.NewAdmissionController(ctx,
 
@@ -52,7 +54,7 @@ func NewDefaultingAdmissionController(ctx context.Context, cmw configmap.Watcher
 		// The path on which to serve the webhook.
 		"/defaulting",
 
-		// The resources to validate and default.
+		// The resources to default.
 		types,
 
 		// A function that infuses the context passed to Validate/SetDefaults with custom metadata.
@@ -76,7 +78,7 @@ func NewValidationAdmissionController(ctx context.Context, cmw configmap.Watcher
 		// The path on which to serve the webhook.
 		"/resource-validation",
 
-		// The resources to validate and default.
+		// The resources to validate.
 		types,
 
 		// A function that infuses the context passed to Validate/SetDefaults with custom metadata.
@@ -88,6 +90,9 @@ func NewValidationAdmissionController(ctx context.Context, cmw configmap.Watcher
 
 		// Whether to disallow unknown fields.
 		true,
+
+		// Extra validating callbacks to be applied to resources.
+		callbacks,
 	)
 }
 


### PR DESCRIPTION
Include empty list of validating callbacks in the example controller

We want to add this to our webhooks so we can remove the variadic argument from /pkg without breaking.