### PR TITLE
Fix update-codegen for the post-go-mod world.

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -19,6 +19,12 @@ set -o nounset
 set -o pipefail
 
 export GO111MODULE=on
+# If we run with -mod=vendor here, then generate-groups.sh looks for vendor files in the wrong place.
+export GOFLAGS=-mod=
+
+if [ -z "${GOPATH:-}" ]; then
+  export GOPATH=$(go env GOPATH)
+fi
 
 REPO_ROOT=$(dirname ${BASH_SOURCE})/..
 CODEGEN_PKG=${CODEGEN_PKG:-$(cd ${REPO_ROOT}; ls -d -1 ./vendor/k8s.io/code-generator 2>/dev/null || echo ../code-generator)}


### PR DESCRIPTION
Per discussion in Slack, adding these flags throughout our repos. Without these, I couldn't run update-codegen.sh locally. Copied over from serving.