### PR TITLE
Update go.mod to specify the module is go1.14

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module knative.dev/sample-controller
 
-go 1.13
+go 1.14
 
 require (
 	contrib.go.opencensus.io/exporter/stackdriver v0.13.1 // indirect


### PR DESCRIPTION
Thus the go commands will default to -mod=vendor

See: https://golang.org/doc/go1.14#go-command